### PR TITLE
skip comments in hosts file

### DIFF
--- a/nxdomain/__init__.py
+++ b/nxdomain/__init__.py
@@ -97,7 +97,9 @@ def parse_block_list(list_type: BlockListType, f: BinaryIO) -> Iterable[str]:
             if not line:
                 continue
             if list_type is BlockListType.hosts:
-                if (match := HOSTS_REGEXP.match(line)) is not None and (
+                if line.startswith('#'):
+                    continue
+                elif (match := HOSTS_REGEXP.match(line)) is not None and (
                     domain := match.group(1).strip()
                 ):
                     yield domain


### PR DESCRIPTION
Commented lines are included in the RPZ output. A diff of the file generated after the change shows google.com is no longer being blocked.

```@@ -22729,7 +22302,6 @@                                                   
 googieapp.com 3600 IN CNAME .                                            
 www.googieapp.com 3600 IN CNAME .                                        
 www.googkle.com 3600 IN CNAME .                                          
-google.com 3600 IN CNAME .                                               
 ads.google.com 3600 IN CNAME .                                           
 adservice.google.com 3600 IN CNAME . 
 adservices.google.com 3600 IN CNAME .                                    
@@ -22737,7 +22309,6 @@                                                   
 analytics.google.com 3600 IN CNAME .                                     
 fundingchoices.google.com 3600 IN CNAME .
 crashlytics2.l.google.com 3600 IN CNAME .                                
-www.google-analytics.l.google.com 3600 IN CNAME .                        
 pagead.l.google.com 3600 IN CNAME .                                      
 pagead-googlehosted.l.google.com 3600 IN CNAME .                         
 partnerad.l.google.com 3600 IN CNAME . ```